### PR TITLE
Add default `path_prefix` and `fabricator_path` to config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'hanami-model'
+gem 'hanami'

--- a/lib/hanami/fabrication.rb
+++ b/lib/hanami/fabrication.rb
@@ -1,6 +1,7 @@
 require "fabrication"
 require "hanami/fabrication/version"
 require "hanami/utils/class"
+require "hanami"
 
 module Fabrication
   module Generator
@@ -29,5 +30,7 @@ module Fabrication
 end
 
 Fabrication.configure do |config|
+  config.path_prefix = Hanami.root
+  config.fabricator_path = 'spec/support/fabricators'
   config.generators << Fabrication::Generator::Hanami
 end


### PR DESCRIPTION
I've faced with problem when I need to use `Fabrication` not only in spec but in other places(like seeds, etc). You need to manually require fabricator and I think it isn't very convenient. So I've decided to add default `path_prefix` and `fabricator_path` to Fabricator configuration.

p.s. It is also available to change config in `initializers` in your Hanami project