### PR TITLE
Use resolved_class instead of _klass

### DIFF
--- a/lib/hanami/fabrication.rb
+++ b/lib/hanami/fabrication.rb
@@ -10,7 +10,7 @@ module Fabrication
       end
 
       def build_instance
-        self._instance = _klass.new(_attributes)
+        self._instance = resolved_class.new(_attributes)
       end
 
       protected
@@ -22,7 +22,7 @@ module Fabrication
       private
 
       def repository
-        ::Hanami::Utils::Class.load!("#{_klass}Repository").new
+        ::Hanami::Utils::Class.load!("#{resolved_class}Repository").new
       end
     end
   end


### PR DESCRIPTION
Fixes warnings from newer versions of fabrication

https://gitlab.com/fabrication-gem/fabrication/-/blob/master/Changelog.markdown#anchor-2290